### PR TITLE
Improve setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,12 +45,12 @@ from setuptools.command.build_ext import build_ext as _build_ext
 
 
 class build_ext(_build_ext):
-    def finalize_options(self):
-        super(build_ext, self).finalize_options()
+    def run(self):
         import numpy
         numpy_inc = numpy.get_include()
         for ext in self.extensions:
             ext.include_dirs.append(numpy_inc)
+        super(build_ext, self).run()
 
 
 geodesic_module = [

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ To build::
 
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext as _build_ext
-import pkg_resources
 
 
 class build_ext(_build_ext):

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ class build_ext(_build_ext):
         numpy_inc = numpy.get_include()
         for ext in self.extensions:
             ext.include_dirs.append(numpy_inc)
-        super(build_ext, self).run()
+        _build_ext.run(self)
 
 
 geodesic_module = [

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@
 #
 
 """
-This module the building of a cython wrapper around a C++ library for 
+This module the building of a cython wrapper around a C++ library for
 calculating the geodesic distance between points on a mesh surface.
 
 To build::
@@ -40,18 +40,31 @@ To build::
 
 """
 
-import numpy
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext as _build_ext
+import pkg_resources
 
-from distutils.core import setup
-from distutils.extension import Extension
-from Cython.Distutils import build_ext
 
-geodesic_module = [Extension(name="gdist",              # Name of extension
-                             sources=["gdist.pyx"],     # Filename of Cython source
-                             language="c++")]           # Cython create C++ source
+class build_ext(_build_ext):
+    def finalize_options(self):
+        super(build_ext, self).finalize_options()
+        import numpy
+        numpy_inc = numpy.get_include()
+        for ext in self.extensions:
+            ext.include_dirs.append(numpy_inc)
 
-include_directories = [numpy.get_include(),     # NumPy dtypes
-                       "geodesic_library"]      # geodesic distance, C++ library.
+
+geodesic_module = [
+        Extension(
+            # Name of extension
+            name="gdist",
+            # Filename of Cython source
+            sources=["gdist.pyx"],
+            # Include files directory (numpy include directory will be
+            # appended later)
+            include_dirs=["geodesic_library"],
+            language="c++")
+]
 
 long_description = """
 The gdist module is a Cython interface to a C++ library
@@ -60,13 +73,12 @@ geodesic distance which is the length of shortest line between two
 vertices on a triangulated mesh in three dimensions, such that the line
 lies on the surface.
 
-The algorithm is due Mitchell, Mount and Papadimitriou, 1987; the implementation
-is due to Danil Kirsanov and the Cython interface to Gaurav Malhotra and
-Stuart Knock.
-"""
+The algorithm is due Mitchell, Mount and Papadimitriou, 1987; the
+implementation is due to Danil Kirsanov and the Cython interface to Gaurav
+Malhotra and Stuart Knock."""
 
 setup(ext_modules=geodesic_module,
-      include_dirs=include_directories,
+      include_dirs=["geodesic_library"],
       cmdclass={'build_ext': build_ext},
       name='gdist',
       license='GPL 2',


### PR DESCRIPTION
The current version of setup.py suffer from a typical problem among scientific
python packages that prevents the package from being installable using pip.

The problem lies in the `import numpy` line. Pip needs to be able to run
`setup.py egg_info` to figure out the dependencies but this fails when
setup.py tried to import numpy, which isn't installed yet.

This patched uses a solution inspired from http://stackoverflow.com/a/21621689.

It consists in implementing a custom build_ext class that defers the need for
numpy presence to building extension time, which is after the requirements
have been installed.

This should be enough to let the user install the package using `pip install gdist`.

~~PS: Adding [WIP] since it still fails when numpy is not present.~~ fixed now
