### PR TITLE
include <algorithm> in geodesic_library/geodesic_mesh_elements.h  to make it compile with VS2015

### DIFF
--- a/geodesic_library/geodesic_mesh_elements.h
+++ b/geodesic_library/geodesic_mesh_elements.h
@@ -10,6 +10,7 @@ faces; and surface points.
 
 #include <assert.h>
 #include <cstddef>
+#include <algorithm>
 
 namespace geodesic{
 


### PR DESCRIPTION
This is e.g. necessary for Anaconda Python 3.5
