### PR TITLE
Fix No such file or directory: 'gdist.cpp issue #12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,5 +79,4 @@ setuptools.setup(name="tvb-" + GEODESIC_NAME,
                  keywords="gdist geodesic distance geo tvb")
 
 shutil.rmtree('tvb_gdist.egg-info', True)
-os.remove(GEODESIC_NAME + '.cpp')
 shutil.rmtree('build', True)

--- a/setup.py
+++ b/setup.py
@@ -80,3 +80,4 @@ setuptools.setup(name="tvb-" + GEODESIC_NAME,
 
 shutil.rmtree('tvb_gdist.egg-info', True)
 shutil.rmtree('build', True)
+os.remove(GEODESIC_NAME + '.cpp')

--- a/setup.py
+++ b/setup.py
@@ -80,4 +80,3 @@ setuptools.setup(name="tvb-" + GEODESIC_NAME,
 
 shutil.rmtree('tvb_gdist.egg-info', True)
 shutil.rmtree('build', True)
-os.remove(GEODESIC_NAME + '.cpp')


### PR DESCRIPTION
Delete os.remove(GEODESIC_NAME + '.cpp') at the end of setup.py file with fix the waking of raceback (most recent call last):
  File "setup.py", line 82, in <module>
    os.remove(GEODESIC_NAME + '.cpp')
OSError: [Errno 2] No such file or directory: 'gdist.cpp' because gdist.cpp no longer exist in the source file.
issue #12 