### PR TITLE
setup.py: Use precise URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,8 +74,7 @@ setuptools.setup(name="tvb-" + GEODESIC_NAME,
                  license='GPL v3',
                  author=TEAM,
                  author_email='tvb.admin@thevirtualbrain.org',
-                 url='http://www.thevirtualbrain.org',
-                 download_url='https://github.com/the-virtual-brain/tvb-geodesic',
+                 url='https://github.com/the-virtual-brain/tvb-geodesic',
                  keywords="gdist geodesic distance geo tvb")
 
 shutil.rmtree('tvb_gdist.egg-info', True)


### PR DESCRIPTION
The website thevirtualbrain.org does not
provide information about this Python package.

Fixes https://github.com/the-virtual-brain/tvb-geodesic/issues/23