### PR TITLE
TVB-3071: set the wheel's numpy dependency to be the oldest numpy that is compatible with the specific python

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04, windows-2019, macOS-11 ]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04, windows-2019, macOS-11 ]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,8 +1,6 @@
 name: Build
 
-on:
-  release:
-    types: [published]
+on: push
 
 jobs:
   build_wheels:
@@ -56,8 +54,8 @@ jobs:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.5.0
-        with:
-          user: ${{ secrets.PYPI_USER }}
-          password: ${{ secrets.PYPI_PASSWORD }}
-#          repository_url: https://test.pypi.org/legacy/
+#      - uses: pypa/gh-action-pypi-publish@v1.5.0
+#        with:
+#          user: ${{ secrets.PYPI_USER }}
+#          password: ${{ secrets.PYPI_PASSWORD }}
+##          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,6 +1,8 @@
 name: Build
 
-on: push
+on:
+  release:
+    types: [published]
 
 jobs:
   build_wheels:
@@ -54,8 +56,8 @@ jobs:
           name: artifact
           path: dist
 
-#      - uses: pypa/gh-action-pypi-publish@v1.5.0
-#        with:
-#          user: ${{ secrets.PYPI_USER }}
-#          password: ${{ secrets.PYPI_PASSWORD }}
-##          repository_url: https://test.pypi.org/legacy/
+      - uses: pypa/gh-action-pypi-publish@v1.5.0
+        with:
+          user: ${{ secrets.PYPI_USER }}
+          password: ${{ secrets.PYPI_PASSWORD }}
+#          repository_url: https://test.pypi.org/legacy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,6 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython", "numpy"]
+requires = ["setuptools",
+    "wheel",
+    "Cython",
+    "oldest-supported-numpy"
+]

--- a/setup.py
+++ b/setup.py
@@ -42,11 +42,9 @@ To build::
 
 import os
 import setuptools
-
 import numpy
 from Cython.Distutils import build_ext
 from Cython.Build.Dependencies import cythonize
-
 
 compiler_directives = {
     "language_level": 3,
@@ -105,7 +103,7 @@ class new_build_ext(build_ext):
 
 setuptools.setup(
     name="tvb-" + GEODESIC_NAME,
-    version="2.1.1",
+    version="2.1.2",
     ext_modules=GEODESIC_MODULE,
     include_dirs=INCLUDE_DIRS,
     cmdclass={"build_ext": new_build_ext},

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ class new_build_ext(build_ext):
 
 setuptools.setup(
     name="tvb-" + GEODESIC_NAME,
-    version="2.1.2",
+    version="2.2",
     ext_modules=GEODESIC_MODULE,
     include_dirs=INCLUDE_DIRS,
     cmdclass={"build_ext": new_build_ext},


### PR DESCRIPTION
Solve the wheel numpy incompatibility problem present in release 2.1.1